### PR TITLE
Typo correction, wifi.php

### DIFF
--- a/wifi.php
+++ b/wifi.php
@@ -84,7 +84,7 @@ class Wifi
             $wlan['MacAddress'] = $result[1];
         }
 
-        preg_match('/inet (?:addr:)? ?([0-9.]+)/i' $strWlan0, $result);
+        preg_match('/inet (?:addr:)? ?([0-9.]+)/i', $strWlan0, $result);
         if (isset($result[1])) {
             $wlan['IPAddress'] = $result[1];
         }


### PR DESCRIPTION
Missing comma in the preg_match on line 87 of wifi.php. 
Without it, wifi pages will fail with error: "Parse error: syntax error, unexpected '$strWlan0' (T_VARIABLE), expecting ',' or ')' in /var/www/emoncms/Modules/wifi/wifi.php on line 87" in the emoncms settings area.
Hope this helps!