### PR TITLE
Use fwrite instead of exec to ensure single quotes can be handled in PSK

### DIFF
--- a/wifi.php
+++ b/wifi.php
@@ -225,7 +225,10 @@ class Wifi
             }
         }
 
-        exec("echo '$config' > /tmp/wifidata",$return);
+        $file = fopen('/tmp/wifidata', 'w');
+        fwrite($file, $config);
+        fclose($file);
+
         system('sudo cp /tmp/wifidata /etc/wpa_supplicant/wpa_supplicant.conf',$returnval);
 
         if (file_exists($settings['openenergymonitor_dir']."/data/wifiAP-enabled")) {


### PR DESCRIPTION
https://github.com/emoncms/wifi/issues/6

Variable interpolation was causing the `exec` argument to expand to something like:

```
echo 'ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev\nupdate_config=1\ncountry=GB\n\n\nnetwork={\n\tssid="MySSID"\n\t#psk="MyPskWithSingleQuote' "\n\tpsk=psketc\n}\n' > /tmp/wifidata
```

This results in the following error:

```
sh: 11: Syntax error: Unterminated quoted string
```

Caused by the extra single quote in the middle of the PSK:

```
...#psk="MyPskWithSingleQuote' "\n\tp...
```

Proposed solution is to use `fwrite` instead of `exec`.

Tested on my emonpi by connecting in AP mode and then connecting to home WiFi network